### PR TITLE
Boundary & Camera Zoom scripts added

### DIFF
--- a/Assets/Standard Assets/2D/Scripts/Boundary.cs
+++ b/Assets/Standard Assets/2D/Scripts/Boundary.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class Boundary : MonoBehaviour {
+	public float minY = 0.0f, minX = 0.0f, maxY = 0.0f, maxX = 0.0f;
+	// Use this for initialization
+	void Start () {
+	
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		Vector2 currentPosition = transform.position;
+		currentPosition.y = Mathf.Clamp (currentPosition.y, minY, maxY);
+		currentPosition.x = Mathf.Clamp (currentPosition.x, minX, maxX);
+		transform.position = currentPosition;
+	}
+}

--- a/Assets/Standard Assets/2D/Scripts/Boundary.cs.meta
+++ b/Assets/Standard Assets/2D/Scripts/Boundary.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9539a5699d45e7442a65a9fe0c5e3abb
+timeCreated: 1442981254
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Standard Assets/2D/Scripts/Zoom.cs
+++ b/Assets/Standard Assets/2D/Scripts/Zoom.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class Zoom : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		Camera.main.orthographicSize = 5;
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		if (Input.GetAxis("Mouse ScrollWheel") > 0 && Camera.main.orthographicSize > 1)
+			Camera.main.orthographicSize -= 1;
+		else if (Input.GetAxis("Mouse ScrollWheel") < 0 && Camera.main.orthographicSize < 10)
+			Camera.main.orthographicSize += 1;
+	}
+}

--- a/Assets/Standard Assets/2D/Scripts/Zoom.cs.meta
+++ b/Assets/Standard Assets/2D/Scripts/Zoom.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7ed2088a83f16ad49b334a24c3f4a5ae
+timeCreated: 1442982746
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Boundary adds x/y limitations on character (can be added to any game
object, I believe) camera zoom function allows player to zoom in/out
with mouse scroll wheel, range of zoom can be easily changed in the
script.
